### PR TITLE
Better Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,11 +1,12 @@
-CC = gcc
-CFLAGS = -ansi -Wall -Werror -Wno-unused -g
+STD=-ansi
+CC=gcc
+CFLAGS=$(STD) -Wall -Werror -Wno-unused -g
 
 all: example 
   
 example: example.c ptest.c
 	$(CC) $(CFLAGS) $^ -o $@
-	./$@
+	./$@; [ $$? == 1 ]
   
 clean:
-	rm example.exe
+	find . -regex ".*example\(\.exe\)*" | xargs rm


### PR DESCRIPTION
Changes include:
- Added configurable C standard flag
- Made Makefile not fail anymore at example target(because failing is expected)
- Made clean target platform independent(did only cleanup on `example.exe`, should also cleanup `example`)
