### PR TITLE
Added example2 to Makefile after fixing it

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@ STD=-ansi
 CC=gcc
 CFLAGS=$(STD) -Wall -Werror -Wno-unused -g
 
-all: example 
+all: example example2
   
 example: example.c ptest.c
 	$(CC) $(CFLAGS) $^ -o $@
@@ -13,4 +13,4 @@ example2: example2.c ptest.c
 	./$@; [ $$? == 1 ]
   
 clean:
-	find . -regex ".*example\(\.exe\)*" | xargs rm
+	find . -regex ".*example\(2\)*\(\.exe\)*" | xargs rm

--- a/Makefile
+++ b/Makefile
@@ -8,5 +8,9 @@ example: example.c ptest.c
 	$(CC) $(CFLAGS) $^ -o $@
 	./$@; [ $$? == 1 ]
   
+example2: example2.c ptest.c
+	$(CC) $(CFLAGS) $^ -o $@
+	./$@; [ $$? == 1 ]
+  
 clean:
 	find . -regex ".*example\(\.exe\)*" | xargs rm

--- a/example2.c
+++ b/example2.c
@@ -1,3 +1,5 @@
+#include <stdbool.h>
+
 #include "ptest.h"
 
 void test_maths(void) {

--- a/example2.c
+++ b/example2.c
@@ -19,7 +19,7 @@ void test_strings(void) {
 void test_stuff(void) { 
   PT_ASSERT(1);
   PT_ASSERT(!0);
-  PT_ASSERT("string");
+  PT_ASSERT("string" != NULL);
 }
 
 void test_failure(void) {


### PR DESCRIPTION
Hey,

I've added the second example to the Makefile. I had to include `stdbool` for that(in order to make `false` and `true` work).
I hope that is okay for you.

Also, `PT_ASSERT("string");` fails on gcc(but works on clang) because of the definition of `PT_ASSERT`, 
which casts the argument to `int`. I had to change that to  `PT_ASSERT("string" != NULL);`.

On clang, the first example fails, because of [their lack of support of nested functions](http://www.llvm.org/bugs/show_bug.cgi?id=6378), but I guess you knew that(due to your README).

Cheers
